### PR TITLE
Wrapper around Mike Innes' BSON.jl

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,14 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[BSON]]
+deps = ["Profile", "Test"]
+git-tree-sha1 = "6453cef4f9cb8ded8e28e4d6d12e11e20eb692ea"
+uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
+version = "0.2.3"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
 [[BinaryProvider]]
 deps = ["Libdl", "SHA"]
 git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
@@ -10,15 +19,48 @@ version = "0.5.4"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ repo = "https://github.com/felipenoris/Mongoc.jl.git"
 version = "0.3.1"
 
 [deps]
+BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -19,6 +19,10 @@ const ISODATE_OFFSET = Dates.UNIXEPOCH + 24 * 60 * 60 * 1000 * 365
 isodate2datetime(millis::Int64) = Dates.epochms2datetime(millis + ISODATE_OFFSET)
 datetime2isodate(dt::DateTime) = Dates.datetime2epochms(dt) - ISODATE_OFFSET
 
+module mi
+import BSON
+end
+
 include("bson.jl")
 include("types.jl")
 include("c_api.jl")
@@ -26,6 +30,7 @@ include("client.jl")
 include("database.jl")
 include("collection.jl")
 include("session.jl")
+include("mi_bson.jl")
 
 function __init__()
     check_deps()

--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -19,9 +19,6 @@ const ISODATE_OFFSET = Dates.UNIXEPOCH + 24 * 60 * 60 * 1000 * 365
 isodate2datetime(millis::Int64) = Dates.epochms2datetime(millis + ISODATE_OFFSET)
 datetime2isodate(dt::DateTime) = Dates.datetime2epochms(dt) - ISODATE_OFFSET
 
-module mi
-import BSON
-end
 
 include("bson.jl")
 include("types.jl")

--- a/src/mi_bson.jl
+++ b/src/mi_bson.jl
@@ -1,12 +1,14 @@
-
+module mi
+import BSON
+end
 
 """Write a symbol using the Mike Innes' encoding"""
 function write_symbol(symbol)
     buf = IOBuffer()
     mi.BSON.@save buf symbol
     buf_start=seek(buf, 0)
-    k = read_bson(buf_start)
-    close(bufs)
+    k, = read_bson(buf_start)
+    close(buf_start)
     k
 end
 

--- a/src/mi_bson.jl
+++ b/src/mi_bson.jl
@@ -1,0 +1,29 @@
+
+
+"""Write a symbol using the Mike Innes' encoding"""
+function write_symbol(symbol)
+    buf = IOBuffer()
+    mi.BSON.@save buf symbol
+    buf_start=seek(buf, 0)
+    k = read_bson(buf_start)
+    close(bufs)
+    k
+end
+
+"Strip additional query information from a BSON result."
+strip_info(doc::Dict) = filter( kv->kv[1]!="_id", doc)
+strip_info(doc::BSON) = BSON( strip_info(Dict(doc)) )
+
+"""
+Load a symbol from a Mongoc document that was written using the Mike Innes'
+ encoding
+"""
+function load_symbol(g_doc::Mongoc.BSON)
+    g_doc_stripped = strip_info(g_doc)
+    buf_read = IOBuffer()
+    write_bson(buf_read, g_doc_stripped )
+    buf_read_start = seek(buf_read,0)
+    mi.BSON.@load buf_read_start symbol
+    close(buf_read_start)
+    symbol
+end

--- a/test/mi_bson_tests.jl
+++ b/test/mi_bson_tests.jl
@@ -4,6 +4,14 @@ using Test
 
 @testset "MI_BSON" begin
     @testset "roundtrip" begin
+        y = 8
+        doc = Mongoc.write_symbol(y)
+        y_ret = Mongoc.load_symbol(doc)
+        @test y == 8
         
+        f = x->x*3
+        doc = Mongoc.write_symbol(f)
+        f_ret = Mongoc.load_symbol(doc)
+        @test f_ret(3)==9
     end
 end

--- a/test/mi_bson_tests.jl
+++ b/test/mi_bson_tests.jl
@@ -1,0 +1,9 @@
+import Mongoc
+
+using Test
+
+@testset "MI_BSON" begin
+    @testset "roundtrip" begin
+        
+    end
+end

--- a/test/mi_bson_tests.jl
+++ b/test/mi_bson_tests.jl
@@ -13,5 +13,12 @@ using Test
         doc = Mongoc.write_symbol(f)
         f_ret = Mongoc.load_symbol(doc)
         @test f_ret(3)==9
+        
+        function g(y,z)
+            y+z
+        end
+        doc = Mongoc.write_symbol(g)
+        g_ret = Mongoc.load_symbol(doc)
+        @test g_ret(1.0,2.0) == g(1.0,2.0)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@
 
 include("bson_tests.jl")
 include("mongodb_tests.jl")
+include("mi_bson_tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@
 #@info("Testing for platform: ", platform_key_abi())
 
 include("bson_tests.jl")
-include("mongodb_tests.jl")
 include("mi_bson_tests.jl")
+include("mongodb_tests.jl")
+


### PR DESCRIPTION
Hi all, I added a wrapper to BSON.jl (https://github.com/MikeInnes/BSON.jl), an all Julia implementation of the BSON format by Mike Innes. It supports arbitrary Julia symbols, which lets us encode anonymous functions as BSON documents. This wrapper is pretty naive, just using a second buffer. The two functions I added make it easy to send the functions to the database. I demonstrated the prototype code over here: https://github.com/afqueiruga/AfqsJuliaUtil.jl/blob/master/mongo.ipynb .