### PR TITLE
Factor a `get_array` function out of `get_value`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,7 @@ Mongoc.BSONObjectId
 Mongoc.BSONCode
 Mongoc.as_json
 Mongoc.as_dict
+Mongoc.get_array
 Mongoc.read_bson
 Mongoc.write_bson
 Mongoc.read_next_bson

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -524,7 +524,7 @@ function get_array(document::BSON, key::AbstractString, ::Type{T}) where T
     if !ok
         error("Key $key not found.")
     end
-    bson_type = bson_iter_type(iter_ref)::BSONType
+    bson_type = bson_iter_type(iter_ref)
     if bson_type != BSON_TYPE_ARRAY
         error("Not a BSON array!")
     end
@@ -532,7 +532,7 @@ function get_array(document::BSON, key::AbstractString, ::Type{T}) where T
 end
 
 function get_array(iter_ref::Ref{BSONIter}, ::Type{T}) where T
-    bson_type = bson_iter_type(iter_ref)::BSONType
+    bson_type = bson_iter_type(iter_ref)
     @assert bson_type == BSON_TYPE_ARRAY
     child_iter_ref = Ref{BSONIter}()
     ok = bson_iter_recurse(iter_ref, child_iter_ref)
@@ -547,7 +547,7 @@ function get_array(iter_ref::Ref{BSONIter}, ::Type{T}) where T
 end
 
 function get_value(iter_ref::Ref{BSONIter})
-    bson_type = bson_iter_type(iter_ref)::BSONType
+    bson_type = bson_iter_type(iter_ref)
 
     if bson_type == BSON_TYPE_UTF8
         return unsafe_string(bson_iter_utf8(iter_ref))

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -511,6 +511,13 @@ function as_dict(iter_ref::Ref{BSONIter}) :: Dict
     return result
 end
 
+"""
+    get_array(doc::BSON, key::AbstractString, ::Type{T})
+
+Get an array from the document with a specified type `T`. This allows obtaining
+a type-stable return value. Note that if an array element cannot be converted
+to the specified type, an error will be thrown.
+"""
 function get_array(document::BSON, key::AbstractString, ::Type{T}) where T
     iter_ref = Ref{BSONIter}()
     ok = bson_iter_init_find(iter_ref, document.handle, key)
@@ -561,14 +568,14 @@ function get_value(iter_ref::Ref{BSONIter})
     elseif bson_type == BSON_TYPE_ARRAY
         return get_array(iter_ref, Any)
     elseif bson_type == BSON_TYPE_DOCUMENT
-      
+
         child_iter_ref = Ref{BSONIter}()
         ok = bson_iter_recurse(iter_ref, child_iter_ref)
         if !ok
             error("Couldn't iterate document inside BSON.")
         end
         return as_dict(child_iter_ref)
-      
+
     elseif bson_type == BSON_TYPE_BINARY
 
         length_ref = Ref{UInt32}()


### PR DESCRIPTION
Also add a user facing api `get_array(document::BSON, key::AbstractString, ::Type{T}) where T`.

This is to allow users to get a type-stable array out of a document when the element type is known.