### PR TITLE
Add UUID support to BSON

### DIFF
--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -2,6 +2,7 @@
 module Mongoc
 using MongoC_jll
 
+import Base.UUID
 using Dates, Serialization
 
 #

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -217,6 +217,10 @@ end
 
 function bson_iter_binary(iter_ref::Ref{BSONIter}, length_ref::Ref{UInt32}, buffer_ref::Ref{Ptr{UInt8}})
     bsonsubtype_ref = Ref(BSON_SUBTYPE_BINARY)
+    bson_iter_binary(iter_ref, bsonsubtype_ref, length_ref, buffer_ref)
+end
+
+function bson_iter_binary(iter_ref::Ref{BSONIter}, bsonsubtype_ref::Ref{BSONSubType}, length_ref::Ref{UInt32}, buffer_ref::Ref{Ptr{UInt8}})
     ccall((:bson_iter_binary, libbson), Cvoid,
           (Ref{BSONIter}, Ref{BSONSubType}, Ref{UInt32}, Ref{Ptr{UInt8}}),
           iter_ref, bsonsubtype_ref, length_ref, buffer_ref)

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -1,6 +1,7 @@
 
 import Mongoc
 
+import Base.UUID
 using Test
 using Dates
 using Distributed
@@ -100,6 +101,13 @@ using Distributed
         bson["ah"] = substring_keys[1]
         @test isa(bson["ah"], String)
         @test bson["ah"] == "Key1"
+    end
+
+    @testset "UUID support" begin
+        uuid = UUID("a1f18b06-2210-499b-8313-28e69090511f")
+        bson = Mongoc.BSON("uuid" => uuid)
+        @test isa(bson["uuid"], UUID)
+        @test bson["uuid"] == uuid
     end
 
     @testset "BSON key/values itr support" begin


### PR DESCRIPTION
Adds support for serializing and deserializing UUID values to and from BSON.

```
uuid = UUIDs.uuid4()
doc = BSON("uuid" => uuid)
@assert isa(doc["uuid"], UUID)
@assert doc["uuid"] == uuid
```