### PR TITLE
Add find_one_and_(delete,replace,update) functions

### DIFF
--- a/src/session.jl
+++ b/src/session.jl
@@ -113,6 +113,24 @@ function aggregate(collection::CollectionSession, bson_pipeline::BSON;
     aggregate(collection.collection, bson_pipeline, flags=flags, options=options_with_session)
 end
 
+function find_one_and_delete(collection::CollectionSession, bson_filter::BSON;
+                             options::Union{Nothing, BSON}=nothing) :: Union{Nothing, BSON}
+    options_with_session = _join(options, get_session(collection))
+    find_one_and_delete(collection.collection, bson_filter, options=options_with_session)
+end
+
+function find_one_and_replace(collection::CollectionSession, bson_filter::BSON, bson_replacement::BSON;
+                              options::Union{Nothing, BSON}=nothing) :: Union{Nothing, BSON}
+    options_with_session = _join(options, get_session(collection))
+    find_one_and_replace(collection.collection, bson_filter, bson_replacement, options=options_with_session)
+end
+
+function find_one_and_update(collection::CollectionSession, bson_filter::BSON, bson_update::BSON;
+                             options::Union{Nothing, BSON}=nothing) :: Union{Nothing, BSON}
+    options_with_session = _join(options, get_session(collection))
+    find_one_and_update(collection.collection, bson_filter, bson_update, options=options_with_session)
+end
+
 function drop(collection::CollectionSession, opts::Union{Nothing, BSON}=nothing)
     drop(collection.collection, opts)
 end

--- a/test/replica_set_tests.jl
+++ b/test/replica_set_tests.jl
@@ -172,6 +172,54 @@ end
         end
 
         @test Mongoc.in_transaction(session)
+
+        let # find_one_and_delete
+            item_to_delete = Mongoc.BSON()
+            item_to_delete["inserted"] = true
+            item_to_delete["to_delete"] = true
+            push!(collection, item_to_delete)
+
+            @test length(collection) == 2
+            @test isempty(collection_unbounded)
+
+            doc = Mongoc.find_one_and_delete(collection, Mongoc.BSON("""{ "to_delete" : true }"""))
+
+            @test !isnothing(doc)
+
+            @test length(collection) == 1
+            @test isempty(collection_unbounded)
+        end
+
+        @test Mongoc.in_transaction(session)
+
+        let # find_one_and_replace
+            selector = Mongoc.BSON()
+            replacement = Mongoc.BSON("""{ "find_one_and_replace": true }""")
+
+            doc = Mongoc.find_one_and_replace(collection, selector, replacement)
+            @test !isnothing(doc)
+        end
+
+        @test Mongoc.in_transaction(session)
+
+        let # find_one_and_update
+            selector = Mongoc.BSON()
+            update = Mongoc.BSON("""{ "\$set": { "find_one_and_update": true } }""")
+
+            doc = Mongoc.find_one_and_update(collection, selector, update)
+            @test !isnothing(doc)
+        end
+
+        @test Mongoc.in_transaction(session)
+
+        let # check updates
+            doc = Mongoc.find_one(collection, Mongoc.BSON())
+            @test doc["find_one_and_replace"]
+            @test doc["find_one_and_update"]
+            @test isempty(collection_unbounded)
+        end
+
+        @test Mongoc.in_transaction(session)
     end
 
     @test !isempty(collection_unbounded)


### PR DESCRIPTION
## Summary

Adds the following functions to the library:

- `find_one_and_delete(::AbstractCollection, filter::BSON; options::Union{BSON,Nothing}) :: Union{BSON,Nothing}`
- `find_one_and_replace(::AbstractCollection, filter::BSON, replacement::BSON; options::Union{BSON,Nothing}) :: Union{BSON,Nothing}`
- `find_one_and_update(::AbstractCollection, filter::BSON, update::BSON; options::Union{BSON,Nothing}) :: Union{BSON,Nothing}`

These are intended to mirror mongodb shell commands:

- [findOneAndDelete](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndDelete/)
- [findOneAndReplace](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/)
- [findOneAndUpdate](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndUpdate/)

## Motivation

The existing `find_and_modify` function does not support transactions.  These functions are also (arguably) slightly nicer to use.

## Considerations

It might make sense to return the op result doc rather than the contained value.  Drivers for other languages differ in how this is handled.

When the filter matches nothing and upsert is `false`, should an error be thrown?