### PR TITLE
Basic MongoDB Timestamp support

### DIFF
--- a/src/bson.jl
+++ b/src/bson.jl
@@ -567,6 +567,8 @@ function get_value(iter_ref::Ref{BSONIter})
     elseif bson_type == BSON_TYPE_DATE_TIME
         millis = Int64(bson_iter_date_time(iter_ref))
         return isodate2datetime(millis)
+    elseif bson_type == BSON_TYPE_TIMESTAMP
+        return bson_iter_timestamp(iter_ref)
     elseif bson_type == BSON_TYPE_ARRAY
         return get_array(iter_ref, Any)
     elseif bson_type == BSON_TYPE_DOCUMENT

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -168,6 +168,14 @@ struct BSONCode
 end
 
 """
+`BSONTimestamp` is a special internal type used by MongoDB replication and sharding.
+"""
+struct BSONTimestamp
+    timestamp::UInt32
+    increment::UInt32
+end
+
+"""
 A `BSON` represents a document in *Binary JSON* format,
 defined at http://bsonspec.org/.
 

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -229,7 +229,7 @@ function bson_iter_timestamp(iter_ref::Ref{BSONIter})
         (Ref{BSONIter}, Ref{UInt32}, Ref{UInt32}),
         iter_ref, timestamp, increment
     )
-    (; timestamp = timestamp[], increment = increment[])
+    BSONTimestamp(timestamp[], increment[])
 end
 
 function bson_iter_recurse(iter_ref::Ref{BSONIter}, child_iter_ref::Ref{BSONIter})

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -220,6 +220,18 @@ function bson_iter_date_time(iter_ref::Ref{BSONIter})
     ccall((:bson_iter_date_time, libbson), Clonglong, (Ref{BSONIter},), iter_ref)
 end
 
+function bson_iter_timestamp(iter_ref::Ref{BSONIter})
+    timestamp = Ref{UInt32}()
+    increment = Ref{UInt32}()
+    ccall(
+        (:bson_iter_timestamp, libbson),
+        Cvoid,
+        (Ref{BSONIter}, Ref{UInt32}, Ref{UInt32}),
+        iter_ref, timestamp, increment
+    )
+    (; timestamp = timestamp[], increment = increment[])
+end
+
 function bson_iter_recurse(iter_ref::Ref{BSONIter}, child_iter_ref::Ref{BSONIter})
     ccall((:bson_iter_recurse, libbson), Bool, (Ref{BSONIter}, Ref{BSONIter}), iter_ref, child_iter_ref)
 end


### PR DESCRIPTION
An internal type in MongoDB, but comes back in some command responses. Currently this throws when displaying the result, so this adds the minimum support to process the timestamp fields.