### PR TITLE
replace_one()

### DIFF
--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -651,6 +651,15 @@ function mongoc_collection_update_many(collection_handle::Ptr{Cvoid}, bson_selec
           collection_handle, bson_selector, bson_update, bson_opts, bson_reply, bson_error_ref)
 end
 
+function mongoc_collection_replace_one(collection_handle::Ptr{Cvoid}, bson_selector::Ptr{Cvoid},
+                                       bson_replacement::Ptr{Cvoid}, bson_opts::Ptr{Cvoid},
+                                       bson_reply::Ptr{Cvoid}, bson_error_ref::Ref{BSONError})
+
+    ccall((:mongoc_collection_replace_one, libmongoc), Bool,
+          (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{BSONError}),
+          collection_handle, bson_selector, bson_replacement, bson_opts, bson_reply, bson_error_ref)
+end
+
 function mongoc_collection_aggregate(collection_handle::Ptr{Cvoid}, flags::QueryFlags,
                                      bson_pipeline::Ptr{Cvoid}, bson_opts::Ptr{Cvoid},
                                      read_prefs::Ptr{Cvoid})

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -115,6 +115,21 @@ function update_many(collection::Collection, selector::BSON, update::BSON;
     return reply
 end
 
+function replace_one(collection::Collection, selector::BSON, replacement::BSON;
+        options::Union{Nothing, BSON}=nothing)
+
+    reply = BSON()
+    err_ref = Ref{BSONError}()
+    options_handle = options == nothing ? C_NULL : options.handle
+    ok = mongoc_collection_replace_one(collection.handle, selector.handle, replacement.handle,
+                                       options_handle, reply.handle, err_ref)
+    if !ok
+        throw(err_ref[])
+    end
+    return reply
+end
+
+
 function BulkOperationResult(reply::BSON, server_id::UInt32)
     BulkOperationResult(reply, server_id, Vector{Union{Nothing, BSONObjectId}}())
 end


### PR DESCRIPTION
Added wrapper for `mongoc_collection_replace_one()`, implementation mostly copied from `update_one()`