### PR TITLE
Use `at-ccall` syntax for better handling of variadic functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.5'
           - '1.6'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [compat]
 DecFP = "1"
 MongoC_jll = "1.16.2"
-julia = "1.3"
+julia = "1.5"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ services:
 
 environment:
   matrix:
-  - julia_version: 1.3
+  - julia_version: 1.5
   - julia_version: 1.6
   - julia_version: latest
 

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -336,10 +336,10 @@ end
 
 function bson_copy_to_excluding_noinit(src_bson_handle::Ptr{Cvoid}, dst_bson_handle::Ptr{Cvoid},
                                        exclude::AbstractString)
-
-    ccall((:bson_copy_to_excluding_noinit, libbson), Cvoid,
-          (Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Cstring),
-          src_bson_handle, dst_bson_handle, exclude, C_NULL)
+    @ccall libbson.bson_copy_to_excluding_noinit(src_bson_handle::Ptr{Cvoid},
+                                                 dst_bson_handle::Ptr{Cvoid},
+                                                 exclude::Cstring;
+                                                 C_NULL::Cstring)::Cvoid
 end
 
 function bson_json_reader_new_from_file(filepath::AbstractString, bson_error_ref::Ref{BSONError})


### PR DESCRIPTION
This makes the package work on `aarch64-apple-darwin` (aka Apple Silicon, or
M1), at least as far as tests are concerned.

Ref: https://github.com/felipenoris/Mongoc.jl/issues/86#issuecomment-962535562.  Fix #86.