### PR TITLE
Configure Julia logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ version = "0.7.1-dev"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MongoC_jll = "90100e71-7732-535a-9be7-2e9affd1cfc1"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 

--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -51,8 +51,8 @@ function _log_handler(level::Cint, domain::Ptr{UInt8}, message::Ptr{UInt8}, ::Pt
     else
         error("Unexpected mongoc log level $level")
     end
-    domain=unsafe_string(domain)
-    message=unsafe_string(message)
+    domain = unsafe_string(domain)
+    message = unsafe_string(message)
     @logmsg jlevel "$domain $message"
     nothing
 end

--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -3,7 +3,7 @@ module Mongoc
 using MongoC_jll
 
 import Base.UUID
-using Dates, DecFP, Serialization
+using Dates, DecFP, Logging, Serialization
 
 #
 # utility functions for date conversion
@@ -25,7 +25,45 @@ include("session.jl")
 include("streams.jl")
 include("gridfs.jl")
 
+const MONGOC_LOG_LEVEL_ERROR = 0
+const MONGOC_LOG_LEVEL_CRITICAL = 1
+const MONGOC_LOG_LEVEL_WARNING = 2
+const MONGOC_LOG_LEVEL_MESSAGE = 3
+const MONGOC_LOG_LEVEL_INFO = 4
+const MONGOC_LOG_LEVEL_DEBUG = 5
+const MONGOC_LOG_LEVEL_TRACE = 6
+
+function _log_handler(level::Cint, domain::Ptr{UInt8}, message::Ptr{UInt8}, ::Ptr{Cvoid})
+    jlevel = if level == MONGOC_LOG_LEVEL_ERROR
+        Logging.Error
+    elseif level == MONGOC_LOG_LEVEL_CRITICAL
+        Logging.Error
+    elseif level == MONGOC_LOG_LEVEL_WARNING
+        Logging.Warn
+    elseif level == MONGOC_LOG_LEVEL_MESSAGE
+        Logging.Info
+    elseif level == MONGOC_LOG_LEVEL_INFO
+        Logging.Info
+    elseif level == MONGOC_LOG_LEVEL_DEBUG
+        Logging.Debug
+    elseif level == MONGOC_LOG_LEVEL_TRACE
+        Logging.Debug
+    else
+        error("Unexpected mongoc log level $level")
+    end
+    domain=unsafe_string(domain)
+    message=unsafe_string(message)
+    @logmsg jlevel "$domain $message"
+    nothing
+end
+
 function __init__()
+    ccall(
+        (:mongoc_log_set_handler, libmongoc),
+        Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}),
+        @cfunction(_log_handler, Cvoid, (Cint, Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid})), C_NULL
+    )
     mongoc_init()
     atexit(mongoc_cleanup)
 end


### PR DESCRIPTION
Found Mongoc to be spamming stdout with message of the like
```
mongoc Cannot override URI option "authSource" from TXT record "authSource=admin"
```
With no direct means to disable other than to override the default log handler.

I considered exposing the log callback API directly, but thought perhaps the cleaner and simpler solution is to redirect logging to the standard Julia logging API, through which users can filter or configure as they are used to in other contexts. That's what this PR is for.