### PR TITLE
Make log handling safe on foreign threads

### DIFF
--- a/src/Mongoc.jl
+++ b/src/Mongoc.jl
@@ -27,7 +27,7 @@ include("gridfs.jl")
 include("logging.jl")
 
 function __init__()
-    init_log_handler()
+    init_log_handler_if_safe()
     mongoc_init()
     atexit(mongoc_cleanup)
 end

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -980,11 +980,11 @@ function mongoc_gridfs_bucket_stream_error(
            stream_handle, bson_error_ref)
 end
 
-function mongoc_set_log_handler(cfunction::Ptr{Cvoid})
+function mongoc_set_log_handler(cfunction::Ptr{Cvoid}, userdata::Ptr{Cvoid} = C_NULL)
     ccall(
         (:mongoc_log_set_handler, libmongoc),
         Cvoid,
         (Ptr{Cvoid}, Ptr{Cvoid}),
-        cfunction, C_NULL
+        cfunction, userdata
     )
 end


### PR DESCRIPTION
This has been causing me intermittent segfaults for a long time, and finally tracked it down.

libmongoc may occasionally log from background threads, for instance if connections are broken or there are other error events in the connection monitor. Since Julia currently doesn't support being called on foreign threads, this blows up our log handler.

I've added a fallback here to revert to the default handler in such events. More elaborate schemes are possible, to queue messages, etc, but comes with a set of complexities and tradeoffs as well.

I couldn't find a clean way to detect if we're on a Julia thread. Asked on Slack without any response. I've implemented something I know to work on 1.7 and 1.8. Hopefully we can find something more stable with time, and if you know any that would be great. I've now limited log interception to Julia 1.7+.