### PR TITLE
Add missing Iterator Interface methods

### DIFF
--- a/src/collection.jl
+++ b/src/collection.jl
@@ -547,7 +547,7 @@ const FIND_ONE_AND_DELETE_FIELDS = Dict(
 
 Delete a document and return it.
 
-See [db.collection.findOneAndDelete](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndDelete/) 
+See [db.collection.findOneAndDelete](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndDelete/)
 for a list of accepted options.
 """
 function find_one_and_delete(collection::Collection, bson_filter::BSON;
@@ -633,7 +633,7 @@ end
 
 Replace a document and return the original.
 
-See [db.collection.findOneAndReplace](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/) 
+See [db.collection.findOneAndReplace](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndReplace/)
 for a list of accepted options.
 """
 function find_one_and_replace(collection::Collection, bson_filter::BSON, bson_replacement::BSON;
@@ -656,7 +656,7 @@ end
 
 Update a document and return the original.
 
-See [db.collection.findOneAndUpdate](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndUpdate/) 
+See [db.collection.findOneAndUpdate](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndUpdate/)
 for a list of accepted options.
 """
 function find_one_and_update(collection::Collection, bson_filter::BSON, bson_update::BSON;
@@ -694,7 +694,17 @@ function _iterate(cursor::Cursor, state::Nothing=nothing)
     end
 end
 
+# Cursor implementation of the iteration interface
 Base.iterate(cursor::Cursor, state::Nothing=nothing) = _iterate(cursor, state)
+
+Base.IteratorSize(::Type{Cursor{T}}) where T = Base.SizeUnknown()
+Base.IteratorEltype(::Type{Cursor{T}}) where T = Base.HasEltype()
+Base.eltype(::Type{Cursor{T}}) where T = BSON
+
+# Collection implementation of the iteration interface
+Base.IteratorSize(::Type{<:AbstractCollection}) = Base.HasLength()
+Base.IteratorEltype(::Type{<:AbstractCollection}) = Base.HasEltype()
+Base.eltype(::Type{<:AbstractCollection}) = BSON
 
 function Base.iterate(coll::Collection)
     cursor = find(coll)
@@ -703,7 +713,7 @@ end
 
 function Base.iterate(coll::Collection, state::Cursor)
     next = _iterate(state)
-    if next == nothing
+    if next === nothing
         return nothing
     else
         doc, _ = next

--- a/test/mongodb_tests.jl
+++ b/test/mongodb_tests.jl
@@ -141,7 +141,7 @@ const DB_NAME = "mongoc"
 
             @testset "collection in comprehension" begin
                 bsons = [bson for bson in coll]
-                @test length(bsons) == 1
+                @test length(bsons) == 4
                 @test eltype(bsons) == Mongoc.BSON
             end
 

--- a/test/mongodb_tests.jl
+++ b/test/mongodb_tests.jl
@@ -133,6 +133,18 @@ const DB_NAME = "mongoc"
             end
             @test i == 1
 
+            @testset "cursor in comprehension" begin
+                bsons = [bson for bson in Mongoc.find(coll, Mongoc.BSON("""{ "hello" : "world" }"""))]
+                @test length(bsons) == 1
+                @test eltype(bsons) == Mongoc.BSON
+            end
+
+            @testset "collection in comprehension" begin
+                bsons = [bson for bson in coll]
+                @test length(bsons) == 1
+                @test eltype(bsons) == Mongoc.BSON
+            end
+
             @testset "collection command_simple" begin
                 result = Mongoc.command_simple(coll, Mongoc.BSON("""{ "collStats" : "new_collection" }"""))
                 @test result["ok"] == 1


### PR DESCRIPTION
By default, `IteratorSize(iter)` is `HasLength()`, which is not true for `Cursor`, so comprehensions fail with missing `length(::Cursor)` method.
The PR adds the necessary interface methods, including the `IteratorEltype()` and `eltype()`, which should help with the type inference.