### PR TITLE
Improve BSON to Dict conversion

### DIFF
--- a/src/bson.jl
+++ b/src/bson.jl
@@ -504,20 +504,15 @@ function Base.iterate(itr::BSONIterator{IterateValues}, ::Nothing=nothing)
 end
 
 """
-    as_dict(document::BSON) :: Dict
+    as_dict(document::BSON) :: Dict{String}
 
 Converts a BSON document to a Julia `Dict`.
 """
-function as_dict(document::BSON) :: Dict
-    result = Dict()
-    for (k, v) in document
-        result[k] = v
-    end
-    return result
-end
+as_dict(document::BSON) =
+    Dict(k => v for (k, v) in document)
 
-function as_dict(iter_ref::Ref{BSONIter}) :: Dict
-    result = Dict()
+function as_dict(iter_ref::Ref{BSONIter})
+    result = Dict{String, Any}()
     while bson_iter_next(iter_ref)
         result[unsafe_string(bson_iter_key(iter_ref))] = get_value(iter_ref)
     end

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -159,6 +159,7 @@ using Distributed
         @test_throws ErrorException doc["invalid key"]
 
         doc_dict = Mongoc.as_dict(doc)
+        @test keytype(doc_dict) === String
         @test doc_dict["a"] == 1
         @test doc_dict["b"] == 2.2
         @test doc_dict["str"] == "my string"
@@ -172,7 +173,7 @@ using Distributed
         # Type-stable API
         @test @inferred(Mongoc.get_array(doc, "float_array", Float64)) == [0.1, 0.2, 0.3, 0.4]
         @test @inferred(Mongoc.get_array(doc, "float_array", Float32)) == Float32[0.1, 0.2, 0.3, 0.4]
-        
+
         @test_throws MethodError Mongoc.get_array(doc, "float_array", String)
         @test_throws ErrorException Mongoc.get_array(doc, "document", Any)
     end


### PR DESCRIPTION
The key type is always *String*, so we can improve type inference by using generator or explicitly specifying key type.

It would also be nice to add `convert(Dict, bson)`/`convert(Dict{K,V}, bson)` methods, let me know what you think.