### PR TITLE
Enhance BSON interface

### DIFF
--- a/src/bson.jl
+++ b/src/bson.jl
@@ -616,10 +616,7 @@ end
 
 function Base.getindex(document::BSON, key::AbstractString)
     iter_ref = Ref{BSONIter}()
-    ok = bson_iter_init_find(iter_ref, document.handle, key)
-    if !ok
-        error("Key $key not found.")
-    end
+    bson_iter_init_find(iter_ref, document.handle, key) || throw(KeyError(key))
     return get_value(iter_ref)
 end
 
@@ -633,10 +630,7 @@ See also [Mongoc.BSONValue](@ref).
 """
 function get_as_bson_value(document::BSON, key::AbstractString) :: BSONValue
    iter_ref = Ref{BSONIter}()
-    ok = bson_iter_init_find(iter_ref, document.handle, key)
-    if !ok
-        error("Key $key not found.")
-    end
+    bson_iter_init_find(iter_ref, document.handle, key) || throw(KeyError(key))
     return get_as_bson_value(iter_ref)
 end
 

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -496,13 +496,17 @@ end
 Base.keys(doc::BSON) = BSONIterator(doc, IterateKeys)
 Base.values(doc::BSON) = BSONIterator(doc, IterateValues)
 
+Base.convert(::Type{Dict}, document::BSON) =
+    Dict{String, Any}(k => v for (k, v) in document)
+Base.convert(::Type{Dict{K,V}}, document::BSON) where {K, V} =
+    Dict{K,V}(k => v for (k, v) in document)
+
 """
     as_dict(document::BSON) :: Dict{String}
 
 Converts a BSON document to a Julia `Dict`.
 """
-as_dict(document::BSON) =
-    Dict(k => v for (k, v) in document)
+as_dict(document::BSON) = convert(Dict, document)
 
 function as_dict(iter_ref::Ref{BSONIter})
     result = Dict{String, Any}()

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -620,6 +620,11 @@ function Base.getindex(document::BSON, key::AbstractString)
     return get_value(iter_ref)
 end
 
+function Base.get(document::BSON, key::AbstractString, default::Any)
+    iter_ref = Ref{BSONIter}()
+    return bson_iter_init_find(iter_ref, document.handle, key) ? get_value(iter_ref) : default
+end
+
 """
     get_as_bson_value(doc, key) :: BSONValue
 

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -475,6 +475,14 @@ struct BSONIterator{M<:BSONIteratorMode}
         new{M}(bson_iter_init(document), document)
 end
 
+Base.IteratorSize(::Type{BSONIterator{M}}) where M = Base.HasLength()
+Base.length(iter::BSONIterator) = length(iter.document)
+
+Base.IteratorEltype(::Type{BSONIterator{M}}) where M = Base.EltypeUnknown()
+Base.IteratorEltype(::Type{BSONIterator{IterateKeys}}) = Base.HasEltype()
+
+Base.eltype(::Type{BSONIterator{IterateKeys}}) = String
+
 Base.iterate(itr::BSONIterator{M}, state::Nothing = nothing) where M =
     bson_iter_next(itr.bson_iter_ref) ?
         (_get(itr.bson_iter_ref, M), state) : nothing

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -437,7 +437,7 @@ Base.length(document::BSON) = bson_count_keys(document.handle)
 has_field(bson::BSON, key::AbstractString) = bson_has_field(bson.handle, key)
 Base.haskey(bson::BSON, key::AbstractString) = has_field(bson, key)
 
-function bson_iter_init(document::BSON) :: Ref{BSONIter}
+function bson_iter_init(document::BSON)
     iter_ref = Ref{BSONIter}()
     ok = bson_iter_init(iter_ref, document.handle)
     if !ok

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -114,17 +114,12 @@ using Distributed
         bson["you"] = "aaa"
         bson["out"] = nothing
 
-        for (k, v) in bson
-            @test (k == "hey" && v == 10) || (k == "you" && v == "aaa") || (k == "out" && v == nothing)
-        end
+        @test ["hey" => 10, "you" => "aaa", "out" => nothing] == [k => v for (k, v) in bson]
+        @test ["hey" => 10, "you" => "aaa", "out" => nothing] == collect(pairs(bson))
 
-        for k in keys(bson)
-            @test k == "hey" || k == "you" || k == "out"
-        end
+        @test ["hey", "you", "out"] == collect(keys(bson))
 
-        for v in values(bson)
-            @test v == 10 || v == "aaa" || v == nothing
-        end
+        @test [10, "aaa", nothing] == collect(values(bson))
     end
 
     @testset "BSON Iterator" begin

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -75,10 +75,7 @@ using Distributed
         @test length(v) == length(unique(v))
 
         v_sorted = sort(v, lt = (a,b) -> Mongoc.bson_oid_compare(a,b) < 0)
-        @test length(v_sorted) == length(v)
-        for i in 1:length(v_sorted)
-            @test v_sorted[i] == v[i]
-        end
+        @test v_sorted == v
     end
 
     @testset "AbstractString support" begin

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -164,6 +164,13 @@ using Distributed
         @test doc_dict["document"] == Dict("a"=>1, "b"=>"b_string")
         @test doc_dict["null"] == nothing
 
+        @testset "convert(Dict, BSON)" begin
+            doc_dict2 = @inferred(convert(Dict, doc))
+            @test doc_dict2 == doc_dict
+            doc_dict3 = @inferred(convert(Dict{String, Any}, doc))
+            @test doc_dict3 == doc_dict
+        end
+
         # Type-stable API
         @test @inferred(Mongoc.get_array(doc, "float_array", Float64)) == [0.1, 0.2, 0.3, 0.4]
         @test @inferred(Mongoc.get_array(doc, "float_array", Float32)) == Float32[0.1, 0.2, 0.3, 0.4]

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -154,6 +154,8 @@ using Distributed
         @test doc["null"] == nothing
 
         @test_throws KeyError doc["invalid key"]
+        @test isequal(get(doc, "invalid key", missing), missing)
+        @test get(doc, "_id", missing) == new_id
 
         doc_dict = Mongoc.as_dict(doc)
         @test keytype(doc_dict) === String

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -153,7 +153,7 @@ using Distributed
         @test doc["document"] == Dict("a"=>1, "b"=>"b_string")
         @test doc["null"] == nothing
 
-        @test_throws ErrorException doc["invalid key"]
+        @test_throws KeyError doc["invalid key"]
 
         doc_dict = Mongoc.as_dict(doc)
         @test keytype(doc_dict) === String


### PR DESCRIPTION
* Improve iterator interface support for *BSON*/*BSONIterator* (similar to #102)
* Make all *BSONIterator* specializations use the same *iterate()* method; the only difference is what kind of value they return (specified by *_get(iter, IteratorMode)* method)
* `bson[key]` would throw *KeyError* if *key* is not found (consistent with *Dict* behaviour)
* Add `get(bson, key, default)` method
* Add `convert(Dict, bson)` method (same effect as `as_dict(bson)`)