### PR TITLE
Track and reduce invalidations

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -1,0 +1,40 @@
+name: Invalidations
+
+on:
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    # Only run on PRs to the default branch.
+    # In the PR trigger above branches can be specified only explicitly whereas this check should work for master, main, or any other default branch
+    if: github.base_ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@v1
+      with:
+        version: '1'
+    - uses: actions/checkout@v3
+    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_pr
+
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_default
+
+    - name: Report invalidation counts
+      run: |
+        echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+        echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+    - name: Check if the PR does increase number of invalidations
+      if: steps.invs_pr.outputs.total > steps.invs_default.outputs.total
+      run: exit 1

--- a/src/bson.jl
+++ b/src/bson.jl
@@ -496,11 +496,6 @@ end
 Base.keys(doc::BSON) = BSONIterator(doc, IterateKeys)
 Base.values(doc::BSON) = BSONIterator(doc, IterateValues)
 
-Base.convert(::Type{Dict}, document::BSON) =
-    Dict{String, Any}(k => v for (k, v) in document)
-Base.convert(::Type{Dict{K,V}}, document::BSON) where {K, V} =
-    Dict{K,V}(k => v for (k, v) in document)
-
 """
     as_dict(document::BSON) :: Dict{String}
 

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -237,6 +237,10 @@ using Distributed
         @test doc["c"] == "string"
         @test doc["d"] == nothing
         @test dict == Mongoc.as_dict(doc)
+        @test dict == Dict(doc)
+        @test dict == Dict{String, Any}(doc)
+        @test dict == convert(Dict, doc)
+        @test dict == convert(Dict{String, Any}, doc)
     end
 
     @testset "BSON Dict API" begin


### PR DESCRIPTION
Method invalidations can be a major source of performance loss in downstream packages, i.e. packages which directly (or indirectly!) use Mongoc.

This PR tries adds a CI test to track invalidations; and also gets rid of some of them. Note that many invalidations are also pulled in from DecFP.jl (but I've already submitted some fixes for that there, and got them merged).