### PR TITLE
Remove `string` methods and implicit conversion to `String` (potentially API breaking)

### DIFF
--- a/src/bson.jl
+++ b/src/bson.jl
@@ -317,15 +317,13 @@ end
 # API
 #
 
-Base.convert(::Type{String}, oid::BSONObjectId) = bson_oid_to_string(oid)
-Base.string(oid::BSONObjectId) = convert(String, oid)
+Base.String(oid::BSONObjectId) = bson_oid_to_string(oid)
 Base.convert(::Type{BSONObjectId}, oid_string::String) = BSONObjectId(oid_string)
 
-Base.convert(::Type{String}, code::BSONCode) = code.code
-Base.string(code::BSONCode) = convert(String, code)
+Base.String(code::BSONCode) = code.code
 Base.convert(::Type{BSONCode}, code_string::String) = BSONCode(code_string)
 
-Base.show(io::IO, oid::BSONObjectId) = print(io, "BSONObjectId(\"", string(oid), "\")")
+Base.show(io::IO, oid::BSONObjectId) = print(io, "BSONObjectId(\"", String(oid), "\")")
 Base.show(io::IO, bson::BSON) = print(io, "BSON(\"", as_json(bson), "\")")
 Base.show(io::IO, code::BSONCode) = print(io::IO, "BSONCode(\"$(code.code)\")")
 

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -18,8 +18,9 @@ using Distributed
     end
 
     @testset "oid conversion" begin
-        local oid::Mongoc.BSONObjectId = "5b9fb22b3192e3fa155693a1"
-        local oid_str::String = oid
+        str = "5b9fb22b3192e3fa155693a1"
+        local oid::Mongoc.BSONObjectId = str
+        @test String(oid) == str
     end
 
     @testset "oid compare" begin
@@ -47,7 +48,7 @@ using Distributed
 
     @testset "oid string" begin
         x = Mongoc.BSONObjectId()
-        y = Mongoc.BSONObjectId(string(x))
+        y = Mongoc.BSONObjectId(String(x))
         @test x == y
 
         @test_throws ErrorException Mongoc.BSONObjectId("invalid_objectid")


### PR DESCRIPTION
Overloading `string` in order to convert an object to a string is against the definition of that function; to quote its docstring: "Create a string from any values using the print function". Instead, one should use `String` for this purpose.

Providing implicit conversion from `BSONObjectId` or `BSONCode` to `String` is also problematic. First off, it causes hundreds of method invalidations in other code, including the Julia library. Secondly, it goes arguably against the spirit of `convert`; the Julia manual says: "`convert` will only convert between types that represent the same basic kind of thing (e.g. different representations of numbers, or different string encodings).".

Note that I left in the `convert` methods which convert `String` into `BSONObjectId` resp. `BSONCode`. While they are also questionable, they are less problematic, as they don't cause widespread invalidations. Since this change is already breaking, I did not want to needlessly add yet more controversy.


This gets rid of ~270 invalidations, mostly in `Pkg`.