### PR TITLE
Remove former alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,3 @@ The source code for the package `Mongoc.jl` is licensed under the [MIT License](
 
 This repository distributes binary assets built from [mongo-c-driver](https://github.com/mongodb/mongo-c-driver) source code,
 which is licensed under [Apache-2.0](https://github.com/mongodb/mongo-c-driver/blob/master/COPYING).
-
-## Alternative Libraries
-
-* [LibBSON.jl](https://github.com/ScottPJones/LibBSON.jl.git)
-
-* [Mongo.jl](https://github.com/ScottPJones/Mongo.jl.git)


### PR DESCRIPTION
Remove outdated alternative clients. 

The last update on both of them is 6 years old.