### PR TITLE
Sanitize URI

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -1,6 +1,6 @@
 
-Base.show(io::IO, uri::URI) = print(io, "URI(\"", uri.uri, "\")")
-Base.show(io::IO, client::Client) = print(io, "Client(URI(\"", client.uri, "\"))")
+Base.show(io::IO, uri::URI) = print(io, "URI(\"", replace(uri.uri, r":.*@" => ":******@"), "\")")
+Base.show(io::IO, client::Client) = print(io, "Client(", client.uri, ")")
 Base.getindex(client::Client, database::String) = Database(client, database)
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,13 +105,13 @@ mutable struct URI
 end
 
 mutable struct ClientPool
-    uri::String
+    uri::URI
     handle::Ptr{Cvoid}
 
     function ClientPool(uri::URI; max_size::Union{Nothing, Integer}=nothing)
         client_pool_handle = mongoc_client_pool_new(uri.handle)
         @assert client_pool_handle != C_NULL "Failed to create client pool from URI $(uri.uri)."
-        client_pool = new(uri.uri, client_pool_handle)
+        client_pool = new(uri, client_pool_handle)
         finalizer(destroy!, client_pool)
 
         if max_size != nothing
@@ -124,7 +124,7 @@ end
 
 # `Client` is a wrapper for C struct `mongoc_client_t`.
 mutable struct Client{T<:Union{Nothing, ClientPool}}
-    uri::String
+    uri::URI
     handle::Ptr{Cvoid}
     pool::T
 end
@@ -132,7 +132,7 @@ end
 function Client(uri::URI)
     client_handle = mongoc_client_new_from_uri(uri.handle)
     @assert client_handle != C_NULL "Failed to create client handle from URI $(uri.uri)."
-    client = Client(uri.uri, client_handle, nothing)
+    client = Client(uri, client_handle, nothing)
     finalizer(destroy!, client)
     return client
 end

--- a/test/mongodb_tests.jl
+++ b/test/mongodb_tests.jl
@@ -44,7 +44,7 @@ const DB_NAME = "mongoc"
             showerror(io, err)
         end
 
-        @test client.uri == "mongodb://localhost:27017"
+        @test client.uri.uri == "mongodb://localhost:27017"
         Mongoc.set_appname!(client, "Runtests")
         db = client[DB_NAME]
         coll = db["new_collection"]


### PR DESCRIPTION
`URI` and the places where it's stored, like `Client` and `ClientPool` can leak credentials through `Base.show()`, which can end up in logs, notebooks, or otherwise persisted.

This change:
- Removes all URI string fields and replaces them with `URI`.
- Sanitizes the URI string in `URI` before outputting to an `io` in `show()`. 

The change is technically breaking if `Client.uri` and `ClientPool.uri` were considered public API, and it's not clear to me if they are. A non-breaking alternative would be to sanitize the strings anywhere they are out output to an `io`, but that to me seemed more brittle. The robust way to deal with this is to enforce containment through a safe type like `URI`, with explicit access to the raw string only when required.