### PR TITLE
Fix UIUD byte ordering

### DIFF
--- a/src/bson.jl
+++ b/src/bson.jl
@@ -590,7 +590,7 @@ function get_value(iter_ref::Ref{BSONIter})
 
         is_uuid = subtype_ref[] == BSON_SUBTYPE_UUID || subtype_ref[] == BSON_SUBTYPE_UUID_DEPRECATED
         if is_uuid && length(result_data) == 16
-            return UUID(reinterpret(UInt128, result_data)[1])
+            return UUID(ntoh(reinterpret(UInt128, result_data)[1]))
         end
 
         return result_data
@@ -743,7 +743,7 @@ function Base.setindex!(document::BSON, value::Vector{UInt8}, key::AbstractStrin
 end
 
 function Base.setindex!(document::BSON, value::UUID, key::AbstractString)
-    value = [reinterpret(UInt8, [value.value])...]
+    value = [reinterpret(UInt8, [hton(value.value)])...]
     ok = bson_append_binary(document.handle, key, -1, BSON_SUBTYPE_UUID, value, UInt32(length(value)))
     if !ok
         error("Couldn't append uuid to BSON document.")

--- a/test/bson_tests.jl
+++ b/test/bson_tests.jl
@@ -104,9 +104,13 @@ using Distributed
 
     @testset "UUID support" begin
         uuid = UUID("a1f18b06-2210-499b-8313-28e69090511f")
+        uuid_bytes = [0xa1, 0xf1, 0x8b, 0x06, 0x22, 0x10, 0x49, 0x9b, 0x83, 0x13, 0x28, 0xe6, 0x90, 0x90, 0x51, 0x1f]
         bson = Mongoc.BSON("uuid" => uuid)
+        Mongoc.bson_append_binary(bson.handle, "uuid2", -1, Mongoc.BSON_SUBTYPE_UUID, uuid_bytes, UInt32(16))
         @test isa(bson["uuid"], UUID)
         @test bson["uuid"] == uuid
+        @test isa(bson["uuid2"], UUID)
+        @test bson["uuid2"] == uuid
     end
 
     @testset "BSON key/values itr support" begin


### PR DESCRIPTION
Byte ordering in MongoDB has a messy history. The old binary subtype 0x03 had implementation defined byte ordering. Technically drivers are meant to expose configuration to deal with this. Subtype 0x04 implements byte order in accordance with RFC 4122, from most to lead significant byte, e.g., canonical network byte order.

See https://github.com/mongodb/specifications/blob/master/source/bson-binary-uuid/uuid.md for details.