### PR TITLE
qualify `Cint` as `Base.Cint` to avoid warnings in Julia 1.12 and 1.13

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -61,7 +61,7 @@ const QueryOrFindAndModifyFlags = Union{QueryFlags, FindAndModifyFlags}
 
 Base.convert(::Type{T}, t::QueryOrFindAndModifyFlags) where {T<:Number} = reinterpret(Cint, t)
 Base.convert(::Type{Q}, n::T) where {Q<:QueryOrFindAndModifyFlags, T<:Number} = reinterpret(Q, n)
-Cint(flags::QueryOrFindAndModifyFlags) = convert(Cint, flags)
+Base.Cint(flags::QueryOrFindAndModifyFlags) = convert(Cint, flags)
 Base.:(|)(flag1::T, flag2::T) where {T<:QueryOrFindAndModifyFlags} = T( Cint(flag1) | Cint(flag2) )
 Base.:(&)(flag1::T, flag2::T) where {T<:QueryOrFindAndModifyFlags} = T( Cint(flag1) & Cint(flag2) )
 


### PR DESCRIPTION
Should avoid warnings like these in current Julia master (preparing for Julia 1.13)
```
┌ Mongoc
│  WARNING: Constructor for type "Cint" was extended in `Mongoc` without explicit qualification or import.
│    NOTE: Assumed "Cint" refers to `Base.Cint`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Cint end`.
│    Hint: To silence the warning, qualify `Cint` as `Base.Cint` or explicitly `import Base: Cint`
│  WARNING: Constructor for type "Cint" was extended in `Mongoc` without explicit qualification or import.
│    NOTE: Assumed "Cint" refers to `Base.Cint`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Cint end`.
│    Hint: To silence the warning, qualify `Cint` as `Base.Cint` or explicitly `import Base: Cint`
└  
```