### PR TITLE
CI: don't specify arch for Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,15 +26,12 @@ jobs:
           - ubuntu-latest
           #- windows-latest
           #- macOS-latest
-        arch:
-          - x64
         mongodb-version: ['5.0']
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
         with:


### PR DESCRIPTION
No need for that, and it can cause problems in the future (e.g. if
someone decides to add macOS tests, where the default arch now is
ARM)
